### PR TITLE
Remove s3/lazySessionOpener with not-lazy sessionOpener

### DIFF
--- a/cmd/copy-uri/main.go
+++ b/cmd/copy-uri/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 
 	"github.com/aaronland/gocloud-blob/app/copyuri"
-	_ "github.com/aaronland/gocloud-blob/s3"		
+	_ "github.com/aaronland/gocloud-blob/s3"
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/memblob"
-	_ "gocloud.dev/blob/s3blob"	
+	_ "gocloud.dev/blob/s3blob"
 )
 
 func main() {

--- a/cmd/copy/main.go
+++ b/cmd/copy/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/aaronland/gocloud-blob/app/copy"
-	_ "github.com/aaronland/gocloud-blob/s3"	
+	_ "github.com/aaronland/gocloud-blob/s3"
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/memblob"
 	_ "gocloud.dev/blob/s3blob"

--- a/cmd/read/main.go
+++ b/cmd/read/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 
 	"github.com/aaronland/gocloud-blob/app/read"
-	_ "github.com/aaronland/gocloud-blob/s3"		
+	_ "github.com/aaronland/gocloud-blob/s3"
 	_ "gocloud.dev/blob/fileblob"
 	_ "gocloud.dev/blob/memblob"
-	_ "gocloud.dev/blob/s3blob"	
+	_ "gocloud.dev/blob/s3blob"
 )
 
 func main() {

--- a/s3/writer.go
+++ b/s3/writer.go
@@ -43,4 +43,3 @@ func NewWriterWithACL(ctx context.Context, bucket *blob.Bucket, path string, str
 
 	return wr, nil
 }
-


### PR DESCRIPTION
* Bug fix: Remove `s3/lazySessionOpener` with not-lazy `sessionOpener` package so that buckets don't get trapped in a `sync.Once` trap.